### PR TITLE
Invalid parsing of time string.

### DIFF
--- a/exTime.py
+++ b/exTime.py
@@ -7,7 +7,7 @@ def convertTimeStringToMinutes( timeString ):
 		return -1
 
 	hours = timeString[ : pos ]
-	minutes = timeString[ pos+1 : ]
+	minutes = timeString[ pos+1 : pos + 3]
 
 	return int(hours) * 60 + int(minutes)
 


### PR DESCRIPTION
I believe the old format of the timetables were hh:mm ; It is not hh:mm:ss so the string representing minutes was listed as 30:00 which is not a valid int.